### PR TITLE
HPCC-24632 Upgrade MySQL client dev version to 5.7.30 for CentOS 7

### DIFF
--- a/packer/aws/el7/hpcc-dev-el7-x86_64.sh.in
+++ b/packer/aws/el7/hpcc-dev-el7-x86_64.sh.in
@@ -105,9 +105,13 @@ sudo make install
 cd ..
 rm -rf git-2.9.5 git-2.9.5.tar.gz
 
-wget http://mysql.mirrors.hoobly.com/Downloads/MySQL-5.6/MySQL-devel-5.6.44-1.el7.x86_64.rpm
-sudo rpm -i MySQL-devel-5.6.44-1.el7.x86_64.rpm
-rm -rf MySQL-devel-5.6.44-1.el7.x86_64.rpm 
+echo "Installing mysql client dev"
+#wget http://mysql.mirrors.hoobly.com/Downloads/MySQL-5.6/MySQL-devel-5.6.44-1.el7.x86_64.rpm
+#sudo rpm -i MySQL-devel-5.6.44-1.el7.x86_64.rpm
+#rm -rf MySQL-devel-5.6.44-1.el7.x86_64.rpm
+wget http://mysql.mirrors.hoobly.com/Downloads/MySQL-5.7/mysql-community-devel-5.7.30-1.el7.x86_64.rpm
+sudo rpm -i mysql-community-devel-5.7.30-1.el7.x86_64.rpm
+rm -f mysql-community-devel-5.7.30-1.el7.x86_64.rpm
 
 echo "Installing Nodejs"
 curl --silent --location https://rpm.nodesource.com/setup_12.x | sudo bash -


### PR DESCRIPTION
Signed-off-by: Mark Kelly <mark.kelly@lexisnexisrisk.com>

Note: see https://github.com/hpcc-systems/HPCC-Platform/pull/14150

That should be merged *BEFORE* this PR.